### PR TITLE
Don't throw an error here

### DIFF
--- a/DBM-Core/DBM-InfoFrame.lua
+++ b/DBM-Core/DBM-InfoFrame.lua
@@ -961,7 +961,6 @@ end
 --Arg 1: spellName, health/powervalue, customfunction, table type. Arg 2: TankIgnore, Powertype, SortFunction, totalAbsorb, sortmethod (table/stacks). Arg 3: SpellFilter, UseIcon. Arg 4: disable onUpdate. Arg 5: sortmethod (playerpower)
 function infoFrame:Show(modMaxLines, event, ...)
 	if DBM.Options.DontShowInfoFrame and not (event or ""):find("test") then
-		error("Invalid event: " .. event or "nil")
 		return
 	end
 	prevLines = 0


### PR DESCRIPTION
Throws an error if the infoframe is disabled, when it really shouldn't.