### PR TITLE
Test package with bwcompat version of DBM-Unified

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,18 @@ jobs:
           WOWI_API_TOKEN: ${{ secrets.WOWI_API_TOKEN }}
           WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
 
+      - name: Create Package
+        uses: QartemisT/packager@master
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          args: -n "DBM-{project-version}{classic}" -d -z
+
+      - uses: actions/upload-artifact@v3
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          name: DBM-PR#${{ github.event.number }}-${{ github.sha }}
+          path: .release/
+
       - name: Send Status to Discord
         uses: nebularg/actions-discord-webhook@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .env
 DBM-Core/Libs/
+/.release
+/release.sh

--- a/.pkgmeta
+++ b/.pkgmeta
@@ -1,7 +1,9 @@
 package-as: DBM-DragonIsles
 
 externals:
-  DBM-DragonIsles: https://github.com/DeadlyBossMods/DBM-Unified
+  DBM-DragonIsles:
+    url: https://github.com/Mitalie/DBM-Unified
+    branch: bwcompat
   DBM-DragonIsles/Libs/CallbackHandler-1.0: https://repos.wowace.com/wow/callbackhandler/trunk/CallbackHandler-1.0
   DBM-DragonIsles/Libs/LibChatAnims: https://repos.wowace.com/wow/libchatanims/trunk/LibChatAnims
   DBM-DragonIsles/Libs/LibDBIcon-1.0: https://repos.wowace.com/wow/libdbicon-1-0/trunk/LibDBIcon-1.0


### PR DESCRIPTION
This PR doesn't need to be merged here, but it builds a zip to test <https://github.com/DeadlyBossMods/DBM-Unified/pull/238>.

Download from the Artifacts dropdown on the Checks tab of this pull request:
![image](https://github.com/DeadlyBossMods/DBM-Retail/assets/16635602/bd82f97a-7f7a-4e9d-9168-991778a5c287)

BigWigs emulation defaults to active as long as actual BigWigs is not loaded. It can be toggled in DBM > Core Options > General Options > Extra Features:
![image](https://github.com/DeadlyBossMods/DBM-Retail/assets/16635602/50bb7034-30b0-4657-aa01-7dbed7a88034)

Test in-game with e.g. https://wago.io/GDblA_dRc which is a version of Jods's https://wago.io/RaidAbilityTimeline with DBM functionality removed, demonstrating that the BigWigs callback emulation is working.