### PR TITLE
Fix incorrect capitalization of addon name in Amirdrassil trash module

### DIFF
--- a/DBM-Raids-Dragonflight/Amirdrassil/AmirdrassilTrash.lua
+++ b/DBM-Raids-Dragonflight/Amirdrassil/AmirdrassilTrash.lua
@@ -1,6 +1,6 @@
 local wowToc, testBuild = DBM:GetTOC()
 if (wowToc < 100200) and not testBuild then return end
-local mod	= DBM:NewMod("AmirdrassilTrash", "DBM-Raids-DragonFlight", 1)
+local mod	= DBM:NewMod("AmirdrassilTrash", "DBM-Raids-Dragonflight", 1)
 local L		= mod:GetLocalizedStrings()
 
 mod:SetRevision("@file-date-integer@")


### PR DESCRIPTION
The mod is neither visible in the GUI nor able to load saved options unless core can link it to its containing addon.