### PR TITLE
Core-Icons: prevent possible nil table while sorting

### DIFF
--- a/DBM-Core/modules/Icons.lua
+++ b/DBM-Core/modules/Icons.lua
@@ -151,6 +151,7 @@ do
 				tinsert(iconUnitTable[scanId], uId)
 			end
 			self:Unschedule(SetIconByTable)
+			self:Unschedule(clearIconTable, scanId)
 			if maxIcon and iconSet[scanId] == maxIcon then
 				SetIconByTable(self, startIcon, descendingIcon, returnFunc, scanId)
 			elseif self:LatencyCheck() then--lag can fail the icons so we check it before allowing.
@@ -283,6 +284,7 @@ do
 				tinsert(iconUnitTable[scanId], uId)
 			end
 			self:Unschedule(SetIconBySortedTable)
+			self:Unschedule(clearIconTable, scanId)
 			if maxIcon and iconSet[scanId] == maxIcon then
 				SetIconBySortedTable(self, sortType, startIcon, descendingIcon, returnFunc, scanId)
 			elseif self:LatencyCheck() then--lag can fail the icons so we check it before allowing.


### PR DESCRIPTION
On very specific conditions, the clearIconTable was being scheduled to be cleared after Icon Set, however, whenever there was a new call to the sorting method, if it happened at the same time as the elapsed scheduling timer (1.5s), it would wipe the table while the sorting was taking place.

The fix attempts to correct the issue by unscheduling the table wipe before sorting.