### PR TITLE
fix: guard DBM.Test nil access in Playground Mode

### DIFF
--- a/DBM-GUI/DBM-GUI_TestUI.lua
+++ b/DBM-GUI/DBM-GUI_TestUI.lua
@@ -14,7 +14,9 @@ local function runTest(test, perspective)
 		allOnYou = perspective == "EverythingOnYou",
 		perspective = perspective ~= DEFAULT and perspective
 	}
-	DBM.Test:RunTest(test, nil, settings)
+	if DBM.Test then
+		DBM.Test:RunTest(test, nil, settings)
+	end
 end
 
 local importTranscriptorFrame
@@ -413,7 +415,7 @@ function DBM_GUI:AddModTestOptionsAbove(panel, mod)
 	local foundTest
 	local function getTestEntries()
 		local values = {}
-		local tests = DBM.Test:GetTestsForMod(mod) or {}
+		local tests = (DBM.Test and DBM.Test:GetTestsForMod(mod)) or {}
 		for _, v in ipairs(tests) do
 			values[#values + 1] = {text = v.name, value = v} -- TODO: add extra info
 		end


### PR DESCRIPTION
Fixes #1254.

Opening Playground Mode with the **DBM Tests addon disabled** crashes with:

```
attempt to call method 'GetTestsForMod' (a nil value)  @ DBM-GUI_TestUI.lua:416
attempt to call method 'RunTest' (a nil value)          @ DBM-GUI_TestUI.lua:17
```

Both sites call methods on `DBM.Test` directly without checking whether it is loaded. The fix guards both call sites:

- `getTestEntries()` — `DBM.Test:GetTestsForMod(mod)` → `(DBM.Test and DBM.Test:GetTestsForMod(mod))`
- `runTest()` — wrapped in `if DBM.Test then ... end`

With DBM Tests disabled, Playground Mode now opens cleanly and the dropdown shows "No test data available" instead of throwing an error.