### PR TITLE
LuaLS: Annotate magic localization tables as table<string, string>

### DIFF
--- a/DBM-Core/modules/objects/Localization.lua
+++ b/DBM-Core/modules/objects/Localization.lua
@@ -104,11 +104,17 @@ local modLocalizations = {}
 function DBM:CreateModLocalization(name)
 	name = tostring(name)
 	local obj = {
+		---@type table<string, string>
 		general = setmetatable({}, returnKey),
+		---@type table<string, string>
 		warnings = setmetatable({}, defaultAnnounceLocalization),
+		---@type table<string, string>
 		options = setmetatable({}, defaultOptionLocalization),
+		---@type table<string, string>
 		timers = setmetatable({}, defaultTimerLocalization),
+		---@type table<string, string?>
 		miscStrings = setmetatable({}, defaultMiscLocalization),
+		---@type table<string, string>
 		cats = setmetatable({}, defaultCatLocalization),
 	}
 	setmetatable(obj, mt)


### PR DESCRIPTION
These can actually never return nil, the actual type is table<T, T> as it returns the key on miss, but the narrower <string, string> is more correct for how we use these.