### PR TITLE
Artemis review

### DIFF
--- a/DBM-GUI/modules/MainFramePrototype.lua
+++ b/DBM-GUI/modules/MainFramePrototype.lua
@@ -681,6 +681,15 @@ function frame:DisplayFrame(targetFrame, secondResize)
 	if secondResize ~= false then
 		resize(targetFrame, scrollBar:IsVisible())
 	end
+	if changed then
+		-- Areas resolve their width during the first display frame. Re-layout on the next frame so controls
+		-- (notably SimpleHTML checkbox labels) use the same settled geometry as when a panel is revisited.
+		C_Timer.After(0, function()
+			if DBM_GUI.currentViewing == targetFrame then
+				self:DisplayFrame(targetFrame, false)
+			end
+		end)
+	end
 	if targetFrame.searchMatchedControl then
 		self:RevealSearchMatch(targetFrame, targetFrame.searchMatchedControl)
 		targetFrame.searchMatchedControl = nil

--- a/DBM-GUI/modules/MainFramePrototype.lua
+++ b/DBM-GUI/modules/MainFramePrototype.lua
@@ -686,7 +686,21 @@ function frame:DisplayFrame(targetFrame, secondResize)
 		-- (notably SimpleHTML checkbox labels) use the same settled geometry as when a panel is revisited.
 		C_Timer.After(0, function()
 			if DBM_GUI.currentViewing == targetFrame then
-				self:DisplayFrame(targetFrame, false)
+				local deferredScrollBar = GetContainerScrollBar()
+				local deferredFOV = GetContainerFOV()
+				local deferredPanelContainer = GetPanelContainer()
+				targetFrame:SetSize(deferredFOV:GetSize())
+				deferredScrollBar:Show()
+				local deferredMax = resize(targetFrame, true) - deferredPanelContainer:GetHeight()
+				if deferredMax > 0 then
+					deferredScrollBar:SetMinMaxValues(0, deferredMax)
+					resize(targetFrame, true)
+				else
+					deferredScrollBar:Hide()
+					deferredScrollBar:SetValue(0)
+					deferredScrollBar:SetMinMaxValues(0, 0)
+					resize(targetFrame, false)
+				end
 			end
 		end)
 	end

--- a/DBM-GUI/modules/PanelPrototype.lua
+++ b/DBM-GUI/modules/PanelPrototype.lua
@@ -745,24 +745,6 @@ do
 		buttonText:SetSize(buttonText:GetWidth(), buttonText:GetContentHeight())
 		buttonText:SetText(button.text) -- SetText is called again, because SimpleHTML needs a refresh after sizing
 		button.myheight = mmax(buttonText:GetContentHeight() + 12, 30)
-		button:HookScript("OnShow", function(self)
-			-- The panel's final width is applied after children are shown, so refresh SimpleHTML labels once on the next frame.
-			if self.simpleHTMLLayoutReady or self.simpleHTMLLayoutQueued then
-				return
-			end
-			self.simpleHTMLLayoutQueued = true
-			C_Timer.After(0, function()
-				self.simpleHTMLLayoutQueued = nil
-				if not self:IsShown() then
-					return
-				end
-				local text = self.textObj
-				text:SetText(self.text)
-				text:SetSize(text:GetWidth(), text:GetContentHeight())
-				text:SetText(self.text)
-				self.simpleHTMLLayoutReady = true
-			end)
-		end)
 		if dbmvar and DBM.Options[dbmvar] ~= nil then
 			button:SetScript("OnShow", function(self)
 				self:SetChecked(DBM.Options[dbmvar])

--- a/DBM-GUI/modules/PanelPrototype.lua
+++ b/DBM-GUI/modules/PanelPrototype.lua
@@ -745,6 +745,24 @@ do
 		buttonText:SetSize(buttonText:GetWidth(), buttonText:GetContentHeight())
 		buttonText:SetText(button.text) -- SetText is called again, because SimpleHTML needs a refresh after sizing
 		button.myheight = mmax(buttonText:GetContentHeight() + 12, 30)
+		button:HookScript("OnShow", function(self)
+			-- The panel's final width is applied after children are shown, so refresh SimpleHTML labels once on the next frame.
+			if self.simpleHTMLLayoutReady or self.simpleHTMLLayoutQueued then
+				return
+			end
+			self.simpleHTMLLayoutQueued = true
+			C_Timer.After(0, function()
+				self.simpleHTMLLayoutQueued = nil
+				if not self:IsShown() then
+					return
+				end
+				local text = self.textObj
+				text:SetText(self.text)
+				text:SetSize(text:GetWidth(), text:GetContentHeight())
+				text:SetText(self.text)
+				self.simpleHTMLLayoutReady = true
+			end)
+		end)
 		if dbmvar and DBM.Options[dbmvar] ~= nil then
 			button:SetScript("OnShow", function(self)
 				self:SetChecked(DBM.Options[dbmvar])


### PR DESCRIPTION
Tab changes invoke another resize() cycle that reflows SimpleHTML checkbox labels. customInline can become visible before its final width is established, leaving its label unrendered until that later pass.

Each checkbox now performs one guarded next-frame SimpleHTML reflow the first time it is shown. This occurs after the containing panel’s final width is available, which addresses labels that otherwise appear only after revisiting a panel.