### PR TITLE
Differ some GUI loading to next frame

### DIFF
--- a/DBM-Core/DBM-Core.lua
+++ b/DBM-Core/DBM-Core.lua
@@ -2317,6 +2317,17 @@ end
 -----------------
 do
 	local callOnLoad = {}
+	local guiLoadPending = false
+
+	local function finishGuiLoad(firstLoad)
+		guiLoadPending = false
+		DBM_GUI:ShowHide()
+		if firstLoad then
+			tsort(callOnLoad, function(v1, v2) return v1[2] < v2[2] end)
+			for _, v in ipairs(callOnLoad) do v[1]() end
+		end
+	end
+
 	function DBM:LoadGUI()
 		if C_AddOns.GetAddOnEnableState("VEM-Core", playerName) >= 1 then
 			self:AddMsg(L.VEM)
@@ -2354,6 +2365,9 @@ do
 			self:AddMsg(L.LOAD_GUI_COMBAT, nil, true)
 			return
 		end
+		if guiLoadPending then
+			return
+		end
 		if self.NewerVersion and private.showConstantReminder >= 1 then
 			AddMsg(self, L.UPDATEREMINDER_HEADER:format(self.NewerVersion, showRealDate(self.HighestRelease)))
 		end
@@ -2377,10 +2391,15 @@ do
 --			end
 			firstLoad = true
 		end
-		DBM_GUI:ShowHide()
 		if firstLoad then
-			tsort(callOnLoad, function(v1, v2) return v1[2] < v2[2] end)
-			for _, v in ipairs(callOnLoad) do v[1]() end
+			-- Loading the GUI already creates every static options panel. Build the dynamic
+			-- mod list in a fresh execution slice to avoid Classic's stricter script limit.
+			guiLoadPending = true
+			C_TimerAfter(0, function()
+				finishGuiLoad(true)
+			end)
+		else
+			finishGuiLoad(false)
 		end
 	end
 

--- a/DBM-GUI/DBM-GUI.lua
+++ b/DBM-GUI/DBM-GUI.lua
@@ -1439,6 +1439,7 @@ do
 
 	function DBM_GUI:UpdateModList()
 		for _, addon in ipairs(DBM.AddOns) do
+			local addonLoaded = C_AddOns.IsAddOnLoaded(addon.modId)
 			if not addon.panel then
 				local customName
 				--Auto truncate Raid, Dungeon, Lair, and World boss mods to only display expansion name in list
@@ -1448,7 +1449,7 @@ do
 				-- Create a Panel for "Naxxramas" "Eye of Eternity" ...
 				addon.panel = DBM_GUI:CreateNewPanel(addon.name or "Error: No-modId", addon.type, false, customName, true, addon.modId)
 
-				if not C_AddOns.IsAddOnLoaded(addon.modId) then
+				if not addonLoaded then
 					local autoLoadFrame = CreateFrame("Frame", nil, addon.panel.frame)
 					autoLoadFrame:SetScript("OnShow", function()
 						if not addon.attemptedAutoLoad then
@@ -1473,7 +1474,7 @@ do
 				end
 			end
 
-			if addon.panel and addon.subTabs and C_AddOns.IsAddOnLoaded(addon.modId) then
+			if addon.panel and addon.subTabs and addonLoaded then
 				if not addon.subPanels then
 					addon.subPanels = {}
 				end
@@ -1487,11 +1488,12 @@ do
 				end
 			end
 
-			for _, v in ipairs(DBM.Mods) do
-				---@class DBMMod
-				local mod = v
-				if mod.modId == addon.modId then
-					if not addon.subTabs or (addon.subPanels and (addon.subPanels[mod.subTab] or mod.subTab == 0)) then
+			local modList = DBM.ModLists[addon.modId]
+			if modList then
+				for _, modId in ipairs(modList) do
+					---@class DBMMod
+					local mod = DBM:GetModByName(modId)
+					if mod and (not addon.subTabs or (addon.subPanels and (addon.subPanels[mod.subTab] or mod.subTab == 0))) then
 						if addon.subTabs and addon.subPanels[mod.subTab] then
 							mod.panel = mod.panel or addon.subPanels[mod.subTab]:CreateNewPanel(mod.id or "Error: DBM.Mods", addon.type, nil, mod.localization.general.name)
 							if mod.showTestUI then


### PR DESCRIPTION
## Summary

Optimizes DBM GUI startup to reduce the chance of hitting World of Warcraft's script execution limit, particularly on Classic Hardcore.

The reported timeout occurred in `CreateNewPanel`, but that call was only where the cumulative execution budget expired. On the first GUI open, WoW loaded the entire `DBM-GUI` addon and immediately constructed the dynamic mod list in the same execution slice.

## Changes

- Deferred first-time dynamic GUI construction to a fresh execution slice after `DBM-GUI` finishes loading.
- Added a pending guard to prevent rapid repeated clicks from scheduling duplicate GUI initialization.
- Preserved synchronous behavior when reopening an already-loaded GUI.
- Preserved the existing ordering of GUI-load callbacks after `ShowHide()`.
- Replaced the nested `DBM.AddOns × DBM.Mods` scan with the existing per-addon `DBM.ModLists[addon.modId]` index.
- Used `DBM:GetModByName()` to resolve indexed mods while preserving registration order.
- Cached each addon's loaded state once per `UpdateModList()` pass.
- Left `PanelPrototype.lua` unchanged because the reported line was the timeout location rather than the root cause.

## Expected Impact

- First GUI open may occur one frame later.
- First-load GUI construction receives a fresh script-execution budget.
- `UpdateModList()` performs less repeated work.
- Subsequent GUI opens remain immediate.
- GUI contents, panel ordering, subtabs, seasonal panels, and test panels retain their existing behavior.

## Validation

- LuaLS reports no errors in the affected files.
- `DBM-Core.lua` passes syntax validation.
- `git diff --check` passes.
- In-game verification is still recommended on Classic Hardcore and Retail.